### PR TITLE
added authorization header to _post_multipart. File upload does not work without

### DIFF
--- a/ckanclient/__init__.py
+++ b/ckanclient/__init__.py
@@ -494,6 +494,13 @@ class CkanClient(object):
         h.putrequest('POST', selector)
         h.putheader('content-type', content_type)
         h.putheader('content-length', str(len(body)))
+        
+        #this is a simple fix. Could most probably be done better.
+        #Authorization headers should be submitted only once. CKAN can use
+        #cookies?
+        h.putheader('Authorization', self.api_key)
+        h.putheader('X-CKAN-API-Key', self.api_key)
+        
         h.endheaders()
         h.send(body)
         errcode, errmsg, headers = h.getreply()


### PR DESCRIPTION
This is just a simple fix for the issue described in this thread on ckan-dev: http://lists.okfn.org/pipermail/ckan-dev/2013-March/004387.html. 
File upload obviously needs some refactoring, there are still issues with submitting binary files and with generating the storage url. I'll try to look after that next week.
