### PR TITLE
Use python-requests to upload file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 ckanclient.egg-info/*
 dist/*
 .*.swp
+.DS_Store


### PR DESCRIPTION
Use python-requests (instead of pycurl) to upload file to CKAN. 
